### PR TITLE
CacheInvalidator trait for Observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,7 @@ All notable changes to `observables` will be documented in this file
 - initial production release
 - bump sfneal/queueables min version to ^2.0
 - refactor classes to remove 'Abstract' prefix from `Event`, `Listener` & `Observer`
+
+
+## 1.0.1 - 2021-04-05
+- make `CacheInvalidator` trait for implementing a `clearCaches()` method in an `Observer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,5 +39,5 @@ All notable changes to `observables` will be documented in this file
 - refactor classes to remove 'Abstract' prefix from `Event`, `Listener` & `Observer`
 
 
-## 1.0.1 - 2021-04-05
+## 1.1.0 - 2021-04-05
 - make `CacheInvalidator` trait for implementing a `clearCaches()` method in an `Observer`

--- a/src/Observers/CacheInvalidator.php
+++ b/src/Observers/CacheInvalidator.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Sfneal\Observers;
+
+
+use Illuminate\Database\Eloquent\Model;
+
+trait CacheInvalidator
+{
+    /**
+     * Clear a Model's related caches.
+     *
+     * @param Model $model
+     */
+    abstract protected function clearCaches(Model $model): void;
+}

--- a/src/Observers/CacheInvalidator.php
+++ b/src/Observers/CacheInvalidator.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Observers;
-
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/src/Observers/Observer.php
+++ b/src/Observers/Observer.php
@@ -2,6 +2,8 @@
 
 namespace Sfneal\Observers;
 
+
+// todo: add ClearCaches interface?
 abstract class Observer
 {
 }

--- a/src/Observers/Observer.php
+++ b/src/Observers/Observer.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Observers;
 
-
 abstract class Observer
 {
 }

--- a/src/Observers/Observer.php
+++ b/src/Observers/Observer.php
@@ -3,7 +3,6 @@
 namespace Sfneal\Observers;
 
 
-// todo: add ClearCaches interface?
 abstract class Observer
 {
 }

--- a/tests/Mocks/PeopleObserver.php
+++ b/tests/Mocks/PeopleObserver.php
@@ -2,13 +2,18 @@
 
 namespace Sfneal\Observables\Tests\Mocks;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Sfneal\Observables\Tests\Models\People;
+use Sfneal\Observers\CacheInvalidator;
 use Sfneal\Observers\Created;
 use Sfneal\Observers\Observer;
 
 class PeopleObserver extends Observer implements Created
 {
+    use CacheInvalidator;
+
     /**
      * Handle a Model's "created" event.
      *
@@ -18,5 +23,16 @@ class PeopleObserver extends Observer implements Created
     public function created(People $people): void
     {
         Event::dispatch(new TestEvent($people->age));
+        $this->clearCaches($people);
+    }
+
+    /**
+     * Clear a Model's related caches.
+     *
+     * @param Model $model
+     */
+    protected function clearCaches(Model $model): void
+    {
+        Cache::flush();
     }
 }


### PR DESCRIPTION
- make `CacheInvalidator` trait for implementing a `clearCaches()` method in an `Observer`